### PR TITLE
Update default value for `origin`

### DIFF
--- a/src/seaborn_image/_context.py
+++ b/src/seaborn_image/_context.py
@@ -100,7 +100,7 @@ def reset_defaults():
     mpl.rcParams.update(mpl.rcParamsDefault)
 
 
-def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=False):
+def set_image(cmap="deep", origin="upper", interpolation="nearest", despine=False):
     """
     Set deaults for plotting images
 
@@ -109,7 +109,7 @@ def set_image(cmap="deep", origin="lower", interpolation="nearest", despine=Fals
     cmap : str, optional
         Colormap to use accross images, by default to "deep".
     origin : str, optional
-        Image origin - same as in `matplotlib.pyplot.imshow`, by default "lower".
+        Image origin - same as in `matplotlib.pyplot.imshow`, by default "upper".
     interpolation : str, optional
         Image interpolation - same as in `matplotlib.pyplot.imshow`, by default "nearest".
     despine : bool, optional


### PR DESCRIPTION
The default value for `origin` is `upper` as described in [matplotlib official documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html)

Using `lower` will make future calls on `matplotlib.plt.imshow` disaplay vertically flipped image, like this:

![param](https://user-images.githubusercontent.com/30312018/203095832-0004a518-1b8d-4e8d-8545-3d618436edab.PNG)
